### PR TITLE
Fixing pypolychord OSError when equals=False

### DIFF
--- a/pypolychord/output.py
+++ b/pypolychord/output.py
@@ -99,9 +99,9 @@ class PolyChordOutput:
         try:
             self._create_pandas_table()
             self.pandas = True
-        except (NameError, FileNotFoundError):
+        except (NameError, FileNotFoundError, OSError):
             self.pandas = False
-                
+
     @property
     def root(self):
         return os.path.join(self.base_dir, self.file_root)


### PR DESCRIPTION
Adding OSError to except statement in pypolychord/output.py to avoid throwing OSError errors when equals=False.

Fixes #14 .