### PR TITLE
bugfixes for 2 corner cases

### DIFF
--- a/pypolychord/_array.hpp
+++ b/pypolychord/_array.hpp
@@ -11,7 +11,7 @@ inline std::vector<double> list_Py2C_double(PyObject* list) {
     {
         PyObject *obj = PyList_GET_ITEM(list, i);
         if (obj==NULL) throw PythonException();
-        if(!PyFloat_Check(obj)) throw PythonException();
+        if(!PyFloat_Check(obj) && !PyInt_Check(obj)) throw PythonException();
         array.push_back(PyFloat_AsDouble(obj));
     }
     return array;

--- a/pypolychord/_array.hpp
+++ b/pypolychord/_array.hpp
@@ -11,7 +11,7 @@ inline std::vector<double> list_Py2C_double(PyObject* list) {
     {
         PyObject *obj = PyList_GET_ITEM(list, i);
         if (obj==NULL) throw PythonException();
-        if(!PyFloat_Check(obj) && !PyInt_Check(obj)) throw PythonException();
+        if(!PyNumber_Check(obj)) throw PythonException();
         array.push_back(PyFloat_AsDouble(obj));
     }
     return array;

--- a/pypolychord/output.py
+++ b/pypolychord/output.py
@@ -178,7 +178,8 @@ class PolyChordOutput:
     def _create_pandas_table(self, paramnames = None):
         # build the paranames for the table
         initial_col_names = ['weight','loglike']
-        n_params = np.genfromtxt('%s_equal_weights.txt' % self.root).shape[1] - 2
+        n_params = (
+            np.atleast_2d(np.genfromtxt('%s_equal_weights.txt' % self.root)).shape[1] - 2)
         if paramnames is None:
             for i in range(n_params):
                 initial_col_names.append('p%d'%i)


### PR DESCRIPTION
This allows a numpy `int` array to be accepted (and casted) as a C float array, and solves a bug that appears when trying to count the name of parameters from a single-line equal-weights output file.