### PR TITLE
Added Sanity checks, to ensure congruent Settings. 

### DIFF
--- a/pypolychord/settings.py
+++ b/pypolychord/settings.py
@@ -207,6 +207,18 @@ class PolyChordSettings:
             raise ValueError('grade_dims must sum to the total dimensionality:'
                              'sum(grade_dims) = %i /= %i' %
                              (len(self.grade_dims), nDims))
+        if not (isinstance(self.grade_dims, list)
+                or not all([isinstance(x, int) for x in self.grade_dims])):
+            raise ValueError('grade_dims must be a list of integers.')
+        if not (isinstance(self.grade_frac, list)
+                or not all(
+                    [isinstance(x, int) or isinstance(x, float)
+                     for x in self.grade_frac]):
+                raise ValueError('grade_dims must be a list of doubles.')
+        if not (len(self.grade_dims) == len(self.grade_frac)):
+                raise ValueError('grade_dims and grade_frac must have the same'
+                                 'len.')
+
 
     @property
     def cluster_dir(self):

--- a/pypolychord/settings.py
+++ b/pypolychord/settings.py
@@ -1,5 +1,10 @@
 import os
 import numpy
+import warnings
+
+def warn(msg):
+    warnings.warn(msg)
+    warnings.warn('This will raise an exception in the future.')
 
 
 class PolyChordSettings:
@@ -190,14 +195,12 @@ class PolyChordSettings:
         self.grade_frac = list(kwargs.pop('grade_frac',
                                           [1.0]*len(self.grade_dims)))
         self.nlives = kwargs.pop('nlives', {})
-
         if kwargs:
-            raise TypeError('Unexpected **kwargs in Contours constructor: %r'
-                            % kwargs)
-
+            warn('Unexpected **kwargs in Contours constructor: %r' % kwargs)
+            
         if sum(self.grade_dims) != nDims:
             raise ValueError('grade_dims must sum to the total dimensionality:'
-                             'sum(%i) /= %i' % (self.grade_dims, nDims))
+                             'sum(grade_dims) = %i /= %i' % (len(self.grade_dims), nDims))
 
     @property
     def cluster_dir(self):
@@ -213,38 +216,35 @@ class PolyChordSettings:
 
     @grade_dims.setter
     def grade_dims(self, value):
-        if value is None or value is []:
+        if value is None or value == []:
+            warn('invalid grade_dims. Defaulting.')
             self._grade_dims = [self.nDims]
         else:
             self._grade_dims = [__natnum(x) for x in value]
-        try:
-            self.grade_frac = self.grade_frac[:len(self.grade_dims)]
-        except ValueError:
-            self.grade_frac = self.grade_frac[:len(self.grade_dims)] + \
-                [1.0]*(len(self.grade_dims) - len(self.grade_frac))
+        # try:
+        #     self.grade_frac = self.grade_frac[:len(self.grade_dims)]
+        # except ValueError:
+        #     self.grade_frac = self.grade_frac[:len(self.grade_dims)] + \
+        #         [1.0]*(len(self.grade_dims) - len(self.grade_frac))
 
     @property
     def grade_frac(self):
         if len(self.grade_dims) != self._grade_frac:
-            raise ValueError(
-                'grade_dims and  grade_frac of incompatible sizes: %i vs %i' %
-                ((len(self.grade_dims), len(self._grade_frac))))
-        else:
-            return self._grade_frac
+            warn('grade_dims doesn\'t match grade_frac.')
+        return self._grade_frac
 
     @grade_frac.setter
     def grade_frac(self, value):
         if len(value) >= len(self.grade_dims):
             self._grade_frac = value[:len(self.grade_dims)]
         else:
-            raise ValueError('Insufficient values to set grade_frac.'
-                             'Need %i, got %i' % (len(value),
-                                                  len(self.grade_dims)))
+            warn('Insufficient values to set grade_frac.'
+                 'Need %i, got %i' % (len(value), len(self.grade_dims)))
+            warn('Defaulting to set, but this will raise in the future.')
 
 
 def __natnum(x: int, minimum=1):
     """Helper function to prevent negative or zero numbers being passed in."""
     if x < minimum:
-        raise ValueError("Expecting a non-zero positive integer: got %i." % x)
-    else:
-        return x
+        warn("Expecting a non-zero positive integer: got %i." % x)
+    return x

--- a/pypolychord/settings.py
+++ b/pypolychord/settings.py
@@ -175,22 +175,23 @@ class PolyChordSettings:
                  logzero=-1e30, boost_posterior=0.0,
                  write_paramnames=False, maximise=False,
                  base_dir='chains', file_root='test',
-                 compression_factor=numpy.exp(-1), seed=-1,
-                 nlives={}, **kwargs):
+                 compression_factor=numpy.exp(-1), seed=-1, nlives={},
+                 posteriors=True, equals=True, write_resume=True,
+                 read_resume=True, write_prior=True, write_dead=True,
+                 write_live=True, write_stats=True,
+                 cluster_posteriors=True, do_clustering=True,
+                 **kwargs):
         args = locals()
         args = {k: args[k] for k in args
                 if k not in ['self', 'nDims', 'nDerived', 'kwargs']}
-
         for k in args:
             setattr(self, k, args[k])
         self.nlive = kwargs.pop('nlive', nDims*25)
         self.num_repeats = kwargs.pop('num_repeats', nDims*5)
-        true_flags = {'posteriors', 'equals', 'write_resume',
-                      'read_resume', 'write_prior', 'write_dead',
-                      'write_live', 'write_stats', 'write_dead',
-                      'cluster_posteriors', 'do_clustering'}
-        for f in true_flags:
-            setattr(self, f, kwargs.pop(f, True))
+        self.grade_dims = list(kwargs.pop('grade_dims',
+                                          [nDims]))
+        self.grade_frac = list(kwargs.pop('grade_frac',
+                                          [1.0]*len(self.grade_dims)))
         # # This is the old way in which we did it.
         # self.nprior = kwargs.pop('nprior', -1)
         # self.nfail = kwargs.pop('nfail', -1)
@@ -217,10 +218,7 @@ class PolyChordSettings:
         # self.file_root = kwargs.pop('file_root', 'test')
         # self.seed = kwargs.pop('seed', -1)
         # self.nlives = kwargs.pop('nlives', {})
-        self.grade_dims = list(kwargs.pop('grade_dims',
-                                          [nDims]))
-        self.grade_frac = list(kwargs.pop('grade_frac',
-                                          [1.0]*len(self.grade_dims)))
+        
         if kwargs:
             warn('Unexpected **kwargs in Contours constructor: %r.' % kwargs)
         self.validate(nDims)

--- a/pypolychord/settings.py
+++ b/pypolychord/settings.py
@@ -5,7 +5,6 @@ import warnings
 
 def warn(msg):
     warnings.warn(msg + ' This will raise an exception in the future.')
-    # raise ValueError (msg)
 
 
 class PolyChordSettings:
@@ -192,33 +191,6 @@ class PolyChordSettings:
                                           [nDims]))
         self.grade_frac = list(kwargs.pop('grade_frac',
                                           [1.0]*len(self.grade_dims)))
-        # # This is the old way in which we did it.
-        # self.nprior = kwargs.pop('nprior', -1)
-        # self.nfail = kwargs.pop('nfail', -1)
-        # self.feedback = kwargs.pop('feedback', 1)
-        # self.max_ndead = kwargs.pop('max_ndead', -1)
-        # self.precision_criterion = kwargs.pop('precision_criterion', 0.001)
-        # self.logzero = kwargs.pop('logzero', -1e30)
-        # self.boost_posterior = kwargs.pop('boost_posterior', 0.0)
-        # self.posteriors = kwargs.pop('posteriors', True)
-        # self.equals = kwargs.pop('equals', True)
-        # self.write_resume = kwargs.pop('write_resume', True)
-        # self.read_resume = kwargs.pop('read_resume', True)
-        # self.write_stats = kwargs.pop('write_stats', True)
-        # self.write_live = kwargs.pop('write_live', True)
-        # self.write_dead = kwargs.pop('write_dead', True)
-        # self.write_prior = kwargs.pop('write_prior', True)
-        # self.cluster_posteriors = kwargs.pop('cluster_posteriors', True)
-        # self.do_clustering = kwargs.pop('do_clustering', True)
-        # self.write_paramnames = kwargs.pop('write_paramnames', False)
-        # self.maximise = kwargs.pop('maximise', False)
-        # self.compression_factor = kwargs.pop('compression_factor',
-            # numpy.exp(-1))
-        # self.base_dir = kwargs.pop('base_dir', 'chains')
-        # self.file_root = kwargs.pop('file_root', 'test')
-        # self.seed = kwargs.pop('seed', -1)
-        # self.nlives = kwargs.pop('nlives', {})
-        
         if kwargs:
             warn('Unexpected **kwargs in Contours constructor: %r.' % kwargs)
         self.validate(nDims)
@@ -233,15 +205,14 @@ class PolyChordSettings:
                              (len(self.grade_dims), nDims))
         if not (isinstance(self.grade_dims, list)
                 or not all([isinstance(x, int) for x in self.grade_dims])):
-            raise ValueError('grade_dims must be a list of integers.')
+            warnings.warn('grade_dims must be a list of integers.')
         if not (isinstance(self.grade_frac, list)
                 or not all(
                     [isinstance(x, int) or isinstance(x, float)
                      for x in self.grade_frac])):
-            raise ValueError('grade_dims must be a list of doubles.')
-        if not (len(self.grade_dims) == len(self.grade_frac)):
-            raise ValueError('grade_dims and grade_frac must have the same'
-                             'len.')
+            warnings.warn('grade_dims must be a list of doubles.')
+        if not len(self.grade_frac) == sum(self.grade_dims):
+            warnings.warn('grade_frac doesn\' match grade_dims.')
 
     @property
     def cluster_dir(self):
@@ -293,4 +264,3 @@ def _natnum(x, minimum=1):
     return x
 
 
-# a = PolyChordSettings(2, 2, grade_dims=[1, 1], grade_frac=[1])

--- a/pypolychord/settings.py
+++ b/pypolychord/settings.py
@@ -175,6 +175,9 @@ class PolyChordSettings:
         self.nprior = kwargs.pop('nprior', -1)
         self.nfail = kwargs.pop('nfail', -1)
         self.do_clustering = kwargs.pop('do_clustering', True)
+        self.cluster_posteriors = kwargs.pop('cluster_posteriors', True)
+        if not self.do_clustering and self.cluster_posteriors:
+            warnings.warn('Not doing clustering, yet cluster posteriors is set.')
         self.feedback = kwargs.pop('feedback', 1)
         self.precision_criterion = kwargs.pop('precision_criterion', 0.001)
         self.logzero = kwargs.pop('logzero', -1e30)
@@ -182,7 +185,6 @@ class PolyChordSettings:
         self.boost_posterior = kwargs.pop('boost_posterior', 0.0)
         self.posteriors = kwargs.pop('posteriors', True)
         self.equals = kwargs.pop('equals', True)
-        self.cluster_posteriors = kwargs.pop('cluster_posteriors', True)
         self.write_resume = kwargs.pop('write_resume', True)
         self.write_paramnames = kwargs.pop('write_paramnames', False)
         self.read_resume = kwargs.pop('read_resume', True)
@@ -213,12 +215,11 @@ class PolyChordSettings:
         if not (isinstance(self.grade_frac, list)
                 or not all(
                     [isinstance(x, int) or isinstance(x, float)
-                     for x in self.grade_frac]):
-                raise ValueError('grade_dims must be a list of doubles.')
+                     for x in self.grade_frac])):
+            raise ValueError('grade_dims must be a list of doubles.')
         if not (len(self.grade_dims) == len(self.grade_frac)):
-                raise ValueError('grade_dims and grade_frac must have the same'
-                                 'len.')
-
+            raise ValueError('grade_dims and grade_frac must have the same'
+                             'len.')
 
     @property
     def cluster_dir(self):

--- a/pypolychord/settings.py
+++ b/pypolychord/settings.py
@@ -283,8 +283,8 @@ class PolyChordSettings:
             self._grade_frac = value[:len(self.grade_dims)]
         else:
             warn('Insufficient values to set grade_frac. '
-                 'Need %i, got %i' % (len(value), len(self.grade_dims))
-                 'Defaulting to set [1.0]*len(self.grade_dims).')
+                 'Need %i, got %i' % (len(value), len(self.grade_dims)))
+            warn('Defaulting to set [1.0]*len(self.grade_dims).')
             self._grade_frac = [1.0]*len(self.grade_dims)
 
 
@@ -295,4 +295,4 @@ def _natnum(x, minimum=1):
     return x
 
 
-a = PolyChordSettings(2, 2, grade_dims=[1, 1], grade_frac=[1])
+# a = PolyChordSettings(2, 2, grade_dims=[1, 1], grade_frac=[1])

--- a/pypolychord/settings.py
+++ b/pypolychord/settings.py
@@ -24,7 +24,7 @@ class PolyChordSettings:
 
     Keyword arguments
     -----------------
-    nlive: int
+    nlive: positive int
         (Default: nDims*25)
         The number of live points.
         Increasing nlive increases the accuracy of posteriors and evidences,
@@ -43,10 +43,13 @@ class PolyChordSettings:
     nprior : int
         (Default: nlive)
         The number of prior samples to draw before starting compression.
+        -1 is equivalent to default.
 
     nfail : int
         (Default: nlive)
         The number of failed spawns before stopping nested sampling.
+        -1 is equivalent to default.
+
 
     do_clustering : boolean
         (Default: True)
@@ -71,6 +74,7 @@ class PolyChordSettings:
         (Default: -1)
         Alternative termination criterion. Stop after max_ndead iterations.
         Set negative to ignore (default).
+
 
     boost_posterior : float
         (Default: 0.0)
@@ -135,17 +139,19 @@ class PolyChordSettings:
         (Default: 'test')
         Root name of the files produced.
 
-    grade_frac : List[float]
+    grade_frac : List[positive float]
         (Default: [1])
         The amount of time to spend in each speed.
         If any of grade_frac are <= 1, then polychord will time each sub-speed,
         and then choose num_repeats for the number of slowest repeats, and
         spend the proportion of time indicated by grade_frac. Otherwise this
         indicates the number of repeats to spend in each speed.
+        Must be positive.
 
-    grade_dims : List[int]
+    grade_dims : List[positive int]
         (Default: nDims)
         The number of parameters within each speed.
+        Must be positive.
 
     nlives : dict {double:int}
         (Default: {})
@@ -153,6 +159,7 @@ class PolyChordSettings:
         between loglike contours and nlive.
         You should still set nlive to be a sensible number, as this indicates
         how often to update the clustering, and to define the default value.
+
     seed : positive int
         (Default: system time in milliseconds)
         Choose the seed to seed the random number generator.
@@ -163,7 +170,6 @@ class PolyChordSettings:
     """
 
     def __init__(self, nDims, nDerived, **kwargs):
-
         self.nlive = kwargs.pop('nlive', nDims*25)
         self.num_repeats = kwargs.pop('num_repeats', nDims*5)
         self.nprior = kwargs.pop('nprior', -1)
@@ -197,10 +203,10 @@ class PolyChordSettings:
         self.nlives = kwargs.pop('nlives', {})
         if kwargs:
             warn('Unexpected **kwargs in Contours constructor: %r' % kwargs)
-            
         if sum(self.grade_dims) != nDims:
             raise ValueError('grade_dims must sum to the total dimensionality:'
-                             'sum(grade_dims) = %i /= %i' % (len(self.grade_dims), nDims))
+                             'sum(grade_dims) = %i /= %i' %
+                             (len(self.grade_dims), nDims))
 
     @property
     def cluster_dir(self):

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ def get_version(short=False):
             if 'version' in line:
                 return line[44:50]
 
+
 pypolychord_module = Extension(
         name='_pypolychord',
         library_dirs=[os.path.join(os.getcwd(), 'lib')],


### PR DESCRIPTION
Meant to solve #47. May need testing, but instead of catching errors and raising errors early, this produces a warning (for now, it's trivial to change to raise ValueError). 

I'm not quite sure about the convention of using negative numbers to set defaults. This is not pythonic. The justification is that this is the convention in other languages, and when interoperating, it's easier to maintain only one version. However, we're already providing the defaults in the doctoring, so we need to duplicate the effort anyway. It may be better to add another module that contains the defaults, and update it. 

