### PR TITLE
bugfix: missing i for int in parameter type string

### DIFF
--- a/pypolychord/_pypolychord.cpp
+++ b/pypolychord/_pypolychord.cpp
@@ -126,7 +126,7 @@ static PyObject *run_pypolychord(PyObject *, PyObject *args)
         
 
     if (!PyArg_ParseTuple(args,
-                "OOOiiiiiiiiddidiiiiiiiiiiidssO!O!O!i:run",
+                "OOOiiiiiiiiddidiiiiiiiiiiidissO!O!O!i:run",
                 &temp_logl,
                 &temp_prior,
                 &temp_dumper,


### PR DESCRIPTION
`PolyChord:synchronous`: Add missing `i` for `int` for the additional boolean sync parameter in the string describing parameter types in `_pypolychord.cpp`.