### PR TITLE
add logL stopping condition

### DIFF
--- a/pypolychord/__init__.py
+++ b/pypolychord/__init__.py
@@ -204,6 +204,7 @@ def run_polychord(loglikelihood, nDims, nDerived, settings,
                      settings.grade_frac,
                      settings.grade_dims,
                      settings.nlives,
-                     settings.seed)
+                     settings.seed,
+                     settings.logLstop)
 
     return PolyChordOutput(settings.base_dir, settings.file_root)

--- a/pypolychord/_pypolychord.cpp
+++ b/pypolychord/_pypolychord.cpp
@@ -5,7 +5,6 @@
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
 
-
 /* Initialize the module */
 #ifdef PYTHON3
 PyMODINIT_FUNC PyInit__pypolychord(void)
@@ -126,7 +125,7 @@ static PyObject *run_pypolychord(PyObject *, PyObject *args)
         
 
     if (!PyArg_ParseTuple(args,
-                "OOOiiiiiiiiddidiiiiiiiiiiidssO!O!O!i:run",
+                "OOOiiiiiiiiddidiiiiiiiiiiidssO!O!O!id:run",
                 &temp_logl,
                 &temp_prior,
                 &temp_dumper,
@@ -162,7 +161,8 @@ static PyObject *run_pypolychord(PyObject *, PyObject *args)
                 &py_grade_dims,
                 &PyDict_Type,
                 &py_nlives,
-                &S.seed
+                &S.seed,
+                &S.logLstop
                 )
             )
         return NULL;

--- a/pypolychord/settings.py
+++ b/pypolychord/settings.py
@@ -153,6 +153,12 @@ class PolyChordSettings:
         a negative seed indicates that you should use the system time in
         milliseconds
 
+    logLstop : float
+        (Default: 1e30)
+        Stopping conditon based on the loglikelihood. Run stops once the
+        smallest loglikelihood amongst the active live points exceeds this
+        value.
+
     """
     def __init__(self, nDims, nDerived, **kwargs):
 
@@ -187,6 +193,7 @@ class PolyChordSettings:
         self.grade_frac = list(kwargs.pop('grade_frac',
                                           [1.0]*len(self.grade_dims)))
         self.nlives = kwargs.pop('nlives', {})
+        self.logLstop = kwargs.pop('logLstop', 1e30)
 
         if kwargs:
             raise TypeError('Unexpected **kwargs in Contours constructor: %r'

--- a/src/polychord/c_interface.cpp
+++ b/src/polychord/c_interface.cpp
@@ -34,6 +34,7 @@ Settings::Settings(int _nDims,int _nDerived):
     grade_dims          {nDims},
     loglikes            {},
     nlives              {},
+    logLstop            {1e30},
     seed                {-1}
 {}
 
@@ -106,6 +107,7 @@ void run_polychord(
             &s.loglikes[0],
             &s.nlives[0],
             s.seed,
+            s.logLstop,
 				fortran_comm
                 );
 

--- a/src/polychord/interfaces.F90
+++ b/src/polychord/interfaces.F90
@@ -293,6 +293,7 @@ contains
             loglikes,&
             nlives,&
             seed,&
+            logLstop,&
             comm) &
             bind(c,name='polychord_c_interface')
 
@@ -348,6 +349,7 @@ contains
         real(c_double), intent(in), value   :: logzero
         integer(c_int), intent(in), value   :: max_ndead
         real(c_double), intent(in), value   :: boost_posterior
+        real(c_double), intent(in), value   :: logLstop
         logical(c_bool), intent(in), value  :: posteriors
         logical(c_bool), intent(in), value  :: equals
         logical(c_bool), intent(in), value  :: cluster_posteriors
@@ -395,6 +397,7 @@ contains
         settings%logzero             = logzero  
         settings%max_ndead           = max_ndead            
         settings%boost_posterior     = boost_posterior      
+        settings%logLstop            = logLstop
         settings%posteriors          = posteriors           
         settings%equals              = equals               
         settings%cluster_posteriors  = cluster_posteriors   

--- a/src/polychord/interfaces.h
+++ b/src/polychord/interfaces.h
@@ -36,6 +36,7 @@ extern "C" void polychord_c_interface(
         double*,
         int*,
         int,
+        double,
 #ifdef USE_MPI
 		  MPI_Fint&
 #else

--- a/src/polychord/interfaces.hpp
+++ b/src/polychord/interfaces.hpp
@@ -38,6 +38,7 @@ struct Settings
     std::vector<double> loglikes;
     std::vector<int> nlives;
     int seed;
+    double logLstop;
 
     Settings(int _nDims=0,int _nDerived=0);
 };

--- a/src/polychord/nested_sampling.F90
+++ b/src/polychord/nested_sampling.F90
@@ -501,7 +501,7 @@ module nested_sampling_module
 
        ! Reached required threshold
 
-       if ( settings%logLstop < MINVAL(RTI%logLp) ) then
+       if ( settings%logLstop < MINVAL(RTI%logLp) .and. RTI%nlive(1) .ge. settings%nlive) then
           write(stdout_unit, *) 'reached ', MINVAL(RTI%logLp), '. threshold ', settings%logLstop,  '. stopping at ', RTI%nlike, ' calls, ', RTI%ndead, 'iterations'
           more_samples_needed = .false.
        end if

--- a/src/polychord/nested_sampling.F90
+++ b/src/polychord/nested_sampling.F90
@@ -473,6 +473,7 @@ module nested_sampling_module
     function more_samples_needed(settings,RTI)
         use settings_module,   only: program_settings
         use run_time_module,   only: run_time_info,live_logZ
+        use utils_module, only: stdout_unit,logsumexp
         implicit none
 
         type(program_settings), intent(in) :: settings
@@ -498,6 +499,12 @@ module nested_sampling_module
             more_samples_needed = .false.
         end if
 
+       ! Reached required threshold
+
+       if ( settings%logLstop < MINVAL(RTI%logLp) ) then
+          write(stdout_unit, *) 'reached ', MINVAL(RTI%logLp), '. threshold ', settings%logLstop,  '. stopping at ', RTI%nlike, ' calls, ', RTI%ndead, 'iterations'
+          more_samples_needed = .false.
+       end if
 
     end function more_samples_needed
 

--- a/src/polychord/settings.f90
+++ b/src/polychord/settings.f90
@@ -12,6 +12,7 @@ module settings_module
     !> Type to contain all of the parameters involved in a nested sampling run
     Type :: program_settings
 
+        real(dp) :: logLstop = 1d30             !> Stop at this threshold
         integer :: nlive = 500                  !> The number of live points
         integer :: num_repeats = -1             !> The number of slow chords to draw
         logical :: do_clustering = .false.      !> Whether to do clustering or not


### PR DESCRIPTION
Adds `logLstop` setting, with default 1e30. Run stops collecting new samples (i.e., `more_samples_needed` gives false) once the smallest loglike amongst active live points exceeds `logLstop`.

The setting is accessible through the Python interface too.