### PR TITLE
numpy int64 incompatibility fix

### DIFF
--- a/pypolychord/polychord.py
+++ b/pypolychord/polychord.py
@@ -176,8 +176,7 @@ def run_polychord(loglikelihood, nDims, nDerived, settings,
     def wrap_prior(cube, theta):
         theta[:] = prior(cube)
 
-    settings.grade_dims = np.array(settings.grade_dims).tolist()
-    settings.num_repeats = np.array(settings.num_repeats).tolist()
+    settings.grade_dims = [int(d) for d in settings.grade_dims]
     settings.nlives = {float(logL):int(nlive) for logL, nlive in settings.nlives.items()}
 
     # Run polychord from module library

--- a/pypolychord/polychord.py
+++ b/pypolychord/polychord.py
@@ -176,6 +176,10 @@ def run_polychord(loglikelihood, nDims, nDerived, settings,
     def wrap_prior(cube, theta):
         theta[:] = prior(cube)
 
+    settings.grade_dims = np.array(settings.grade_dims).tolist()
+    settings.num_repeats = np.array(settings.num_repeats).tolist()
+    settings.nlives = {float(logL):int(nlive) for logL, nlive in settings.nlives.items()}
+
     # Run polychord from module library
     _pypolychord.run(wrap_loglikelihood,
                      wrap_prior,

--- a/src/polychord/ini.f90
+++ b/src/polychord/ini.f90
@@ -226,7 +226,6 @@ contains
     end function get_string
 
     function get_double(file_name,key_word,dflt)
-        use utils_module,  only: STR_LENGTH
         use abort_module,  only: halt_program
         character(len=*),intent(in)  :: file_name !> The name of the file to search in
         character(len=*),intent(in)  :: key_word  !> keyword to search for
@@ -247,7 +246,6 @@ contains
     end function get_double
 
     subroutine get_doubles(file_name,key_word,doubles)
-        use utils_module,  only: STR_LENGTH
         use array_module,  only: reallocate
         character(len=*),intent(in)  :: file_name !> The name of the file to search in
         character(len=*),intent(in)  :: key_word  !> keyword to search for
@@ -274,7 +272,6 @@ contains
     end subroutine get_doubles
 
     subroutine get_integers(file_name,key_word,integers)
-        use utils_module,  only: STR_LENGTH
         use array_module,  only: reallocate
         character(len=*),intent(in)  :: file_name !> The name of the file to search in
         character(len=*),intent(in)  :: key_word  !> keyword to search for
@@ -301,7 +298,6 @@ contains
     end subroutine get_integers
 
     function get_integer(file_name,key_word,dflt)
-        use utils_module,  only: STR_LENGTH
         use abort_module,  only: halt_program
         character(len=*),intent(in)  :: file_name !> The name of the file to search in
         character(len=*),intent(in)  :: key_word  !> keyword to search for
@@ -324,7 +320,6 @@ contains
     end function get_integer
 
     function get_logical(file_name,key_word,dflt)
-        use utils_module,  only: STR_LENGTH
         use abort_module,  only: halt_program
         character(len=*),intent(in)  :: file_name !> The name of the file to search in
         character(len=*),intent(in)  :: key_word  !> keyword to search for
@@ -467,7 +462,6 @@ contains
 
 
     subroutine next_element(line_buffer,delimiter) 
-        use utils_module,  only: STR_LENGTH
         implicit none
         character(len=:), allocatable, intent(inout)  :: line_buffer ! Line buffer
         character :: delimiter
@@ -475,7 +469,6 @@ contains
     end subroutine next_element
 
     subroutine get_prior_params(prior_params,line_buffer)
-        use utils_module,  only: STR_LENGTH
         implicit none
         character(len=:), allocatable,intent(inout)               :: line_buffer ! Line buffer
         real(dp),allocatable,dimension(:),intent(out) :: prior_params      ! prior parameters

--- a/src/polychord/maximiser.F90
+++ b/src/polychord/maximiser.F90
@@ -64,7 +64,7 @@ module maximise_module
 
     function do_maximisation(loglikelihood,prior,settings,RTI, posterior) result(max_point)
         use calculate_module, only: calculate_point
-        use utils_module, only: stdout_unit, fmt_len, sort_doubles
+        use utils_module, only: sort_doubles
         use settings_module,  only: program_settings
         use run_time_module,   only: run_time_info
         use read_write_module,   only: write_max_file, mean
@@ -100,10 +100,10 @@ module maximise_module
 
 
         real(dp) :: max_loglike
-        integer :: imax, cluster_id
+        integer :: cluster_id
         real(dp), dimension(settings%nTotal) :: max_point
         integer :: nlike, j
-        real(dp), dimension(settings%nDims)   :: xl, xu, x
+        real(dp), dimension(settings%nDims)   :: x
         real(dp), dimension(settings%nDims,settings%nDims+1) :: simplex
         real(dp), dimension(settings%nDims+1) :: f
         real(dp), dimension(settings%nlive) :: l

--- a/src/polychord/nelder_mead.f90
+++ b/src/polychord/nelder_mead.f90
@@ -24,7 +24,6 @@ module nelder_mead_module
             integer :: n, j
             integer, dimension(size(f)) :: i
             double precision, dimension(size(f)-1) :: xo, xr, xe, xc, xmax
-            double precision, dimension(size(f)-1,size(f)-1) :: V
             double precision :: fr, fe, fc
             double precision :: det0, det1
 

--- a/src/polychord/read_write.F90
+++ b/src/polychord/read_write.F90
@@ -1002,8 +1002,6 @@ module read_write_module
         
         type(program_settings),intent(in)                    :: settings       !> Program settings
 
-        integer :: i
-
         call check_directories(settings)
 
         open(unit=properties_unit,file=trim(properties_file(settings)))


### PR DESCRIPTION
This PR fixes the maddening incompatibility between `np.int64` and `int` types, which means that if you pass a `settings.grade_dims` containing integers derived from a numpy array you get the virtually unreadable warning `"grade_dims must be a list of integers"`, since when printed they both appear to be integers (until you inspect the `type(...)`.

A relatively straightforward fix by pythonically converting to the format that polychord expects.
