### PR TITLE
Equal probability of live point spawning in any cluster

### DIFF
--- a/src/polychord/clustering.f90
+++ b/src/polychord/clustering.f90
@@ -10,7 +10,7 @@ module KNN_clustering
     !! Points belong to the same cluster if they are in either of each others k
     !! nearest neighbor sets. 
     !!
-    !! The algorithm computes the k nearest neihbor sets from the similarity
+    !! The algorithm computes the k nearest neighbor sets from the similarity
     !! matrix, and then tests
     recursive function NN_clustering(similarity_matrix,num_clusters) result(cluster_list)
         use utils_module, only: relabel
@@ -113,7 +113,7 @@ module KNN_clustering
 
                 ! If they're not in the same cluster already...
                 if(c(i)/=c(j)) then
-                    ! ... check to see if they are within each others k nearest neihbors...
+                    ! ... check to see if they are within each others k nearest neighbors...
                     if( neighbors( knn(:,i),knn(:,j) ) ) then
 
                         ! If they are then relabel cluster_i and cluster_j to the smaller of the two

--- a/src/polychord/generate.F90
+++ b/src/polychord/generate.F90
@@ -37,6 +37,7 @@ module generate_module
         integer :: seed_choice
 
         real(dp), dimension(RTI%ncluster) :: probs
+        real(dp), dimension(RTI%ncluster) :: equal_probs
 
         ! 0) Calculate an array proportional to the volumes
         probs = RTI%logXp                 ! prob_p = log( X_p )
@@ -44,7 +45,10 @@ module generate_module
         probs = exp(probs)                ! prob_p = X_p/(sum_q X_q)
 
         ! 1) Pick cluster in proportion to the set of volume estimates of the active clusters
-        seed_cluster = random_integer_P(probs)
+        ! Changed this to be equal probability of each cluster
+        equal_probs = 1.
+
+        seed_cluster = random_integer_P(equal_probs)
 
         ! 3) Pick a random integer in between 1 and the number of live points in the cluster 'p'
         seed_choice = random_integer(RTI%nlive(seed_cluster))

--- a/src/polychord/random_utils.F90
+++ b/src/polychord/random_utils.F90
@@ -537,7 +537,7 @@ module random_module
     !! The probability is defined by the input array, and need not be
     !! normalised.
     !!
-    !! E.g: If one reieves an array (/ 50.0, 120.0, 30.0 /), this function will
+    !! E.g: If one receives an array (/ 50.0, 120.0, 30.0 /), this function will
     !! return:
     !! |---|-----------------|
     !! | 1 | 25% of the time |


### PR DESCRIPTION
(I think) I've made the probability of new seeds appearing in each cluster equal. This makes the behaviour with the double-Gaussian example on a similar level (by eye) to MultiNest: 

![investigate](https://user-images.githubusercontent.com/52655393/181246891-e5705a58-0326-4200-8f85-3b0f6f95cc96.png)

Obviously I know this is only effective for this example, but suggests this might be where the problem is.
