### PR TITLE
Correct root=root -> root=0 in make_resume_file

### DIFF
--- a/pypolychord/polychord.py
+++ b/pypolychord/polychord.py
@@ -253,7 +253,7 @@ def make_resume_file(settings, loglikelihood, prior):
             recvbuf = np.empty(sum(sendcounts), dtype=int)
         else:
             recvbuf = None
-        comm.Gatherv(sendbuf=sendbuf, recvbuf=(recvbuf, sendcounts), root=root)
+        comm.Gatherv(sendbuf=sendbuf, recvbuf=(recvbuf, sendcounts), root=0)
 
         lives = np.reshape(sendbuf, (len(settings.cube_samples), len(lives[0])))
     else:

--- a/pypolychord/polychord.py
+++ b/pypolychord/polychord.py
@@ -232,6 +232,7 @@ def make_resume_file(settings, loglikelihood, prior):
         rank = comm.Get_rank()
         size = comm.Get_size()
     except ImportError:
+        MPI = False
         rank = 0
         size = 1
 
@@ -245,7 +246,7 @@ def make_resume_file(settings, loglikelihood, prior):
         nDerived = len(derived)
         lives.append(np.concatenate([cube,theta,derived,[logL_birth, logL]]))
 
-    try:
+    if MPI:
         sendbuf = np.array(lives).flatten()
         sendcounts = np.array(comm.gather(len(sendbuf)))
         if rank == 0:
@@ -255,7 +256,7 @@ def make_resume_file(settings, loglikelihood, prior):
         comm.Gatherv(sendbuf=sendbuf, recvbuf=(recvbuf, sendcounts), root=root)
 
         lives = np.reshape(sendbuf, (len(settings.cube_samples), len(lives[0])))
-    except NameError:
+    else:
         lives = np.array(lives)
 
     if rank == 0:

--- a/src/polychord/clustering.f90
+++ b/src/polychord/clustering.f90
@@ -10,7 +10,7 @@ module KNN_clustering
     !! Points belong to the same cluster if they are in either of each others k
     !! nearest neighbor sets. 
     !!
-    !! The algorithm computes the k nearest neihbor sets from the similarity
+    !! The algorithm computes the k nearest neighbor sets from the similarity
     !! matrix, and then tests
     recursive function NN_clustering(similarity_matrix,num_clusters) result(cluster_list)
         use utils_module, only: relabel
@@ -113,7 +113,7 @@ module KNN_clustering
 
                 ! If they're not in the same cluster already...
                 if(c(i)/=c(j)) then
-                    ! ... check to see if they are within each others k nearest neihbors...
+                    ! ... check to see if they are within each others k nearest neighbors...
                     if( neighbors( knn(:,i),knn(:,j) ) ) then
 
                         ! If they are then relabel cluster_i and cluster_j to the smaller of the two

--- a/src/polychord/clustering.f90
+++ b/src/polychord/clustering.f90
@@ -10,7 +10,7 @@ module KNN_clustering
     !! Points belong to the same cluster if they are in either of each others k
     !! nearest neighbor sets. 
     !!
-    !! The algorithm computes the k nearest neighbor sets from the similarity
+    !! The algorithm computes the k nearest neihbor sets from the similarity
     !! matrix, and then tests
     recursive function NN_clustering(similarity_matrix,num_clusters) result(cluster_list)
         use utils_module, only: relabel
@@ -113,7 +113,7 @@ module KNN_clustering
 
                 ! If they're not in the same cluster already...
                 if(c(i)/=c(j)) then
-                    ! ... check to see if they are within each others k nearest neighbors...
+                    ! ... check to see if they are within each others k nearest neihbors...
                     if( neighbors( knn(:,i),knn(:,j) ) ) then
 
                         ! If they are then relabel cluster_i and cluster_j to the smaller of the two


### PR DESCRIPTION
Previously, `make_resume_file()` in `polychord.py` (used only when the user provides their own initial samples) uses a `try... except NameError` block to identify whether MPI has been imported. However, the same block refers to root without it being defined, which will also throw a NameError.

Here I have corrected `root=root` to `root=0`, and updated the MPI check to set `MPI=False` if it can't be imported, and use an if instead of exception handling.