### PR TITLE
`make_resume_file()` incompatible with MPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@
    :target: https://arxiv.org/abs/1506.00171
    :alt: Open-access paper
 
-PolyChord v 1.20.2
+PolyChord v 1.20.3
 
 Will Handley, Mike Hobson & Anthony Lasenby
 

--- a/pypolychord/__init__.py
+++ b/pypolychord/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "1.20.2"
+__version__ = "1.20.3"
 from pypolychord.settings import PolyChordSettings
 from pypolychord.polychord import run_polychord

--- a/pypolychord/polychord.py
+++ b/pypolychord/polychord.py
@@ -250,16 +250,16 @@ def make_resume_file(settings, loglikelihood, prior):
         sendbuf = np.array(lives).flatten()
         sendcounts = np.array(comm.gather(len(sendbuf)))
         if rank == 0:
-            recvbuf = np.empty(sum(sendcounts), dtype=int)
+            recvbuf = np.empty(sum(sendcounts))
         else:
             recvbuf = None
         comm.Gatherv(sendbuf=sendbuf, recvbuf=(recvbuf, sendcounts), root=0)
 
-        lives = np.reshape(sendbuf, (len(settings.cube_samples), len(lives[0])))
-    else:
-        lives = np.array(lives)
-
     if rank == 0:
+        if MPI:
+            lives = np.reshape(recvbuf, (len(settings.cube_samples), len(lives[0])))
+        else:
+            lives = np.array(lives)
         with open(resume_filename,"w") as f:
             def write(var):
                 var = np.atleast_1d(var)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,3 @@
 [build-system]
 requires = ["setuptools", "wheel", "numpy"]
 build-backend = "setuptools.build_meta"
-
-[project]
-name = "pypolychord"
-dynamic = ["version"]
-
-[project.optional-dependencies]
-cube_samples = ["fortranformat"]
-
-[tool.setuptools.dynamic]
-version = {attr = "pypolychord.__version__"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
 [build-system]
 requires = ["setuptools", "wheel", "numpy"]
 build-backend = "setuptools.build_meta"
+
+[project.optional_dependencies]
+cube_samples = ["fortranformat"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "pypolychord"
 dynamic = ["version"]
 
-[project.optional_dependencies]
+[project.optional-dependencies]
 cube_samples = ["fortranformat"]
 
 [tool.setuptools.dynamic]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,5 +2,12 @@
 requires = ["setuptools", "wheel", "numpy"]
 build-backend = "setuptools.build_meta"
 
+[project]
+name = "pypolychord"
+dynamic = ["version"]
+
 [project.optional_dependencies]
 cube_samples = ["fortranformat"]
+
+[tool.setuptools.dynamic]
+version = {attr = "pypolychord.__version__"}

--- a/src/polychord/feedback.f90
+++ b/src/polychord/feedback.f90
@@ -28,7 +28,7 @@ module feedback_module
             write(stdout_unit,'("")')
             write(stdout_unit,'("PolyChord: Next Generation Nested Sampling")')
             write(stdout_unit,'("copyright: Will Handley, Mike Hobson & Anthony Lasenby")')
-            write(stdout_unit,'("  version: 1.20.2")')
+            write(stdout_unit,'("  version: 1.20.3")')
             write(stdout_unit,'("  release: 1st June 2021")')
             write(stdout_unit,'("    email: wh260@mrao.cam.ac.uk")')
             write(stdout_unit,'("")')


### PR DESCRIPTION
pypolychord/polychord.py::`make_resume_file()` does not work with more than one MPI process.

It looks like the send and receive buffers were mixed up, though I admit I have absolutely no idea why `recvbuf.dtype` was set to int.

I have visually checked that the live points written to the resume file by `make_resume_file()` are the same numbers as the provided `PolyChordSettings.cube_samples`.

(I should probably have suspected something would go wrong after not personally pushing my changes in #92 very hard, and here we are)

