### PR TITLE
Add pytests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -78,7 +78,7 @@ jobs:
         python -m pip install mpi4py
 
     - name: Install pypolychord
-      run: pip install -v .
+      run: pip install -v '.[test]'
 
     - name: Test pypolychord (no MPI)
       run: python -m pytest tests

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,7 +43,7 @@ jobs:
       run: python run_pypolychord.py
 
     - name: Test pypolychord (MPI)
-      run: mpirun -np 3 python run_pypolychord.py
+      run: mpirun --oversubscribe -np 3 python run_pypolychord.py
 
     - name: Test pypolychord (anesthetic)
       if: ${{ ! contains( '3.6, 3.7', matrix.python-version ) }}
@@ -84,4 +84,4 @@ jobs:
       run: python -m pytest tests
 
     - name: Test pypolychord (MPI)
-      run: mpirun -np 3 python -m pytest tests --only-mpi 
+      run: mpirun --oversubscribe -np 3 python -m pytest tests --only-mpi 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -75,7 +75,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install mpi4py
+        python -m pip install mpi4py pytest pytest-mpi fortranformat
 
     - name: Install pypolychord
       run: pip install -v '.[test]'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,7 +43,7 @@ jobs:
       run: python run_pypolychord.py
 
     - name: Test pypolychord (MPI)
-      run: mpirun -np 2 python run_pypolychord.py
+      run: mpirun -np 3 python run_pypolychord.py
 
     - name: Test pypolychord (anesthetic)
       if: ${{ ! contains( '3.6, 3.7', matrix.python-version ) }}
@@ -84,4 +84,4 @@ jobs:
       run: python -m pytest tests
 
     - name: Test pypolychord (MPI)
-      run: mpirun -np 2 python -m pytest tests --only-mpi 
+      run: mpirun -np 3 python -m pytest tests --only-mpi 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,3 +50,38 @@ jobs:
       run: |
         pip install -r requirements.txt
         python run_pypolychord.py
+
+
+  tests:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        include:
+          - os: ubuntu-20.04
+            python-version: '3.6'
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies (Linux)
+      run: sudo apt-get install gfortran libopenmpi-dev
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install mpi4py
+
+    - name: Install pypolychord
+      run: pip install -v .
+
+    - name: Test pypolychord (no MPI)
+      run: python -m pytest tests
+
+    - name: Test pypolychord (MPI)
+      run: mpirun -np 2 python -m pytest tests --only-mpi 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
 [build-system]
 requires = ["setuptools", "wheel", "numpy"]
 build-backend = "setuptools.build_meta"
+
+[project.optional-dependencies]
+test = ["pytest", "pytest-mpi"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,5 +2,12 @@
 requires = ["setuptools", "wheel", "numpy"]
 build-backend = "setuptools.build_meta"
 
+[project]
+name = "pypolychord"
+dynamic = ["version"]
+
 [project.optional-dependencies]
 test = ["pytest", "pytest-mpi"]
+
+[tool.setuptools.dynamic]
+version = {attr = "pypolychord.__version__"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,3 @@
 [build-system]
 requires = ["setuptools", "wheel", "numpy"]
 build-backend = "setuptools.build_meta"
-
-[project]
-name = "pypolychord"
-dynamic = ["version"]
-
-[project.optional-dependencies]
-test = ["pytest", "pytest-mpi"]
-
-[tool.setuptools.dynamic]
-version = {attr = "pypolychord.__version__"}

--- a/tests/test_run_pypolychord.py
+++ b/tests/test_run_pypolychord.py
@@ -37,8 +37,6 @@ cube_samples_settings.feedback = 0
                          [(default_settings, gaussian_likelihood, 4, 1),
                           (cube_samples_settings, gaussian_likelihood, 4, 1)])
 def test_run(settings, likelihood, nDims, nDerived):
-    settings.file_root += '_mpi'
-
     # Define a box uniform prior from -1 to 1
     def prior(hypercube):
         """ Uniform prior from [-1,1]^D. """

--- a/tests/test_run_pypolychord.py
+++ b/tests/test_run_pypolychord.py
@@ -1,0 +1,54 @@
+import pytest
+import numpy as np
+import pypolychord
+from pypolychord.settings import PolyChordSettings
+from pypolychord.priors import UniformPrior
+
+
+def gaussian_likelihood(theta):
+    """ Simple Gaussian Likelihood"""
+
+    sigma = 0.1
+
+    nDims = len(theta)
+    r2 = sum(theta**2)
+    logL = -np.log(2*np.pi*sigma*sigma)*nDims/2.0
+    logL += -r2/2/sigma/sigma
+
+    return logL, [r2]
+
+
+default_settings = PolyChordSettings(4, 1)
+default_settings.file_root = 'gaussian'
+default_settings.nlive = 200
+default_settings.do_clustering = True
+default_settings.read_resume = False
+
+
+@pytest.mark.parametrize("settings, likelihood, nDims, nDerived", [(default_settings, gaussian_likelihood, 4, 1)])
+def test_run(settings, likelihood, nDims, nDerived):
+    # Define a four-dimensional spherical gaussian likelihood,
+    # width sigma=0.1, centered on the 0 with one derived parameter.
+    # The derived parameter is the squared radius
+
+    # Define a box uniform prior from -1 to 1
+
+    def prior(hypercube):
+        """ Uniform prior from [-1,1]^D. """
+        return UniformPrior(-1, 1)(hypercube)
+
+    # Optional dumper function giving run-time read access to
+    # the live points, dead points, weights and evidences
+
+    def dumper(live, dead, logweights, logZ, logZerr):
+        print("Last dead point:", dead[-1])
+
+    # Run PolyChord
+
+    output = pypolychord.run_polychord(likelihood, nDims, nDerived, settings, prior, dumper)
+
+    # Create a paramnames file
+
+    paramnames = [('p%i' % i, r'\theta_%i' % i) for i in range(nDims)]
+    paramnames += [('r*', 'r')]
+    output.make_paramnames_files(paramnames)


### PR DESCRIPTION
PolyChordLite doesn't currently have any tests besides checking that `run_pypolychord.py` runs. This PR adds tests using `pytest`, which are currently:

- Replicating `run_pypolychord.py`
- The above plus using `cube_samples`(which will fail with MPI until #101 is complete)
Both with and without MPI

This framework would allow an array of different likelihoods and settings to be iterated over without needing another `run_something.py` every time.