### PR TITLE
Make live point generation deterministic

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@
    :target: https://arxiv.org/abs/1506.00171
    :alt: Open-access paper
 
-PolyChord v 1.20.2
+PolyChord v 1.21.0
 
 Will Handley, Mike Hobson & Anthony Lasenby
 

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@
    :target: https://arxiv.org/abs/1506.00171
    :alt: Open-access paper
 
-PolyChord v 1.21.0
+PolyChord v 1.20.2
 
 Will Handley, Mike Hobson & Anthony Lasenby
 

--- a/pypolychord/__init__.py
+++ b/pypolychord/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "1.20.2"
+__version__ = "1.21.0"
 from pypolychord.settings import PolyChordSettings
 from pypolychord.polychord import run_polychord

--- a/pypolychord/__init__.py
+++ b/pypolychord/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "1.21.0"
+__version__ = "1.20.2"
 from pypolychord.settings import PolyChordSettings
 from pypolychord.polychord import run_polychord

--- a/run_pypolychord.py
+++ b/run_pypolychord.py
@@ -45,6 +45,7 @@ settings.file_root = 'gaussian'
 settings.nlive = 200
 settings.do_clustering = True
 settings.read_resume = False
+settings.seed = 1
 
 #| Run PolyChord
 

--- a/run_pypolychord.py
+++ b/run_pypolychord.py
@@ -45,7 +45,6 @@ settings.file_root = 'gaussian'
 settings.nlive = 200
 settings.do_clustering = True
 settings.read_resume = False
-settings.seed = 1
 
 #| Run PolyChord
 

--- a/src/polychord/feedback.f90
+++ b/src/polychord/feedback.f90
@@ -28,8 +28,8 @@ module feedback_module
             write(stdout_unit,'("")')
             write(stdout_unit,'("PolyChord: Next Generation Nested Sampling")')
             write(stdout_unit,'("copyright: Will Handley, Mike Hobson & Anthony Lasenby")')
-            write(stdout_unit,'("  version: 1.21.0")')
-            write(stdout_unit,'("  release: 25th October 2023")')
+            write(stdout_unit,'("  version: 1.20.2")')
+            write(stdout_unit,'("  release: 1st June 2021")')
             write(stdout_unit,'("    email: wh260@mrao.cam.ac.uk")')
             write(stdout_unit,'("")')
         end if

--- a/src/polychord/feedback.f90
+++ b/src/polychord/feedback.f90
@@ -28,7 +28,7 @@ module feedback_module
             write(stdout_unit,'("")')
             write(stdout_unit,'("PolyChord: Next Generation Nested Sampling")')
             write(stdout_unit,'("copyright: Will Handley, Mike Hobson & Anthony Lasenby")')
-            write(stdout_unit,'("  version: 1.20.2")')
+            write(stdout_unit,'("  version: 1.21.0")')
             write(stdout_unit,'("  release: 1st June 2021")')
             write(stdout_unit,'("    email: wh260@mrao.cam.ac.uk")')
             write(stdout_unit,'("")')

--- a/src/polychord/feedback.f90
+++ b/src/polychord/feedback.f90
@@ -28,8 +28,8 @@ module feedback_module
             write(stdout_unit,'("")')
             write(stdout_unit,'("PolyChord: Next Generation Nested Sampling")')
             write(stdout_unit,'("copyright: Will Handley, Mike Hobson & Anthony Lasenby")')
-            write(stdout_unit,'("  version: 1.20.2")')
-            write(stdout_unit,'("  release: 1st June 2021")')
+            write(stdout_unit,'("  version: 1.21.0")')
+            write(stdout_unit,'("  release: 25th October 2023")')
             write(stdout_unit,'("    email: wh260@mrao.cam.ac.uk")')
             write(stdout_unit,'("")')
         end if

--- a/src/polychord/generate.F90
+++ b/src/polychord/generate.F90
@@ -111,7 +111,7 @@ module generate_module
         character(len=fmt_len) :: fmt_dbl ! writing format variable
 
         integer :: nlike ! number of likelihood calls
-        integer :: nprior, ndiscarded,
+        integer :: nprior, ndiscarded
         integer :: ngenerated ! use to track order points are generated in
 
         real(dp) :: time0,time1,total_time

--- a/src/polychord/generate.F90
+++ b/src/polychord/generate.F90
@@ -69,7 +69,7 @@ module generate_module
         use array_module,     only: add_point
         use abort_module
 #ifdef MPI
-        use mpi_module, only: mpi_bundle,is_root,linear_mode,throw_point,catch_point,more_points_needed,sum_integers,sum_doubles,request_point,no_more_points,scatter_points,gather_points
+        use mpi_module, only: mpi_bundle,is_root,linear_mode,sum_integers,sum_doubles,scatter_points,gather_points
 #else
         use mpi_module, only: mpi_bundle,is_root,linear_mode
 #endif

--- a/src/polychord/generate.F90
+++ b/src/polychord/generate.F90
@@ -199,7 +199,7 @@ module generate_module
                 end if
 
 
-                call scatter_points(live_points,live_point,mpi_information,settings%nTotal)
+                call scatter_points(live_points,live_point,mpi_information)
 
                 ! if live points have been set to -1 then exit loop
                 if (any(live_point<0)) exit
@@ -212,7 +212,7 @@ module generate_module
                 if(live_point(settings%l0)>settings%logzero) total_time = total_time + time1-time0
 
 
-                call gather_points(live_points,live_point,mpi_information,settings%nTotal)
+                call gather_points(live_points,live_point,mpi_information)
                     ! Recieve a point from any worker
 
                 if (is_root(mpi_information)) then

--- a/src/polychord/generate.F90
+++ b/src/polychord/generate.F90
@@ -117,7 +117,7 @@ module generate_module
         real(dp) :: time0,time1,total_time
         real(dp),dimension(size(settings%grade_dims)) :: speed
 
-        integer :: i
+        integer :: live_point_index ! Start index of the live point in the live_points array.
 
         ! Initialise number of likelihood calls to zero here
         nlike = 0
@@ -216,10 +216,10 @@ module generate_module
                     ! Recieve a point from any worker
 
                 if (is_root(mpi_information)) then
-                    do i=1, mpi_information%nprocs * settings%nTotal, settings%nTotal
+                    do live_point_index=1, mpi_information%nprocs * settings%nTotal, settings%nTotal
                         if (RTI%nlive(1)>=nprior) exit ! exit loop if enough points have been generated
 
-                        live_point=live_points(i:i+settings%nTotal-1)
+                        live_point=live_points(live_point_index:live_point_index+settings%nTotal-1)
 
                         ! If its valid, add it to the array
                         if(live_point(settings%l0)>settings%logzero) then

--- a/src/polychord/generate.F90
+++ b/src/polychord/generate.F90
@@ -69,7 +69,7 @@ module generate_module
         use array_module,     only: add_point
         use abort_module
 #ifdef MPI
-        use mpi_module, only: mpi_bundle,is_root,linear_mode,sum_integers,sum_doubles,scatter_points,gather_points
+        use mpi_module, only: mpi_bundle,is_root,linear_mode,throw_point,catch_point,more_points_needed,sum_integers,sum_doubles,request_point,no_more_points
 #else
         use mpi_module, only: mpi_bundle,is_root,linear_mode
 #endif
@@ -106,7 +106,6 @@ module generate_module
 #endif
 
         real(dp), dimension(settings%nTotal) :: live_point ! Temporary live point array
-        real(dp), dimension(settings%nTotal*mpi_information%nprocs) :: live_points ! Temporary live point array for generation
 
 
         character(len=fmt_len) :: fmt_dbl ! writing format variable
@@ -117,7 +116,6 @@ module generate_module
         real(dp) :: time0,time1,total_time
         real(dp),dimension(size(settings%grade_dims)) :: speed
 
-        integer :: live_point_index ! Start index of the live point in the live_points array.
 
         ! Initialise number of likelihood calls to zero here
         nlike = 0
@@ -187,61 +185,64 @@ module generate_module
         else 
             !===================== PARALLEL MODE =======================
 
-            do while(.true.)
-                if(is_root(mpi_information)) then
-                    ! root generates random numbers and scatters them to the workers
-                    if (RTI%nlive(1)<nprior)then
-                        live_points = random_reals(size(live_points)) ! Generate random coordinates
-                    else
-                        ! set live points to -1 to indicate that no more points are needed
-                        live_points = -1d0
-                    end if
-                end if
+            if(is_root(mpi_information)) then
+                ! The root node just recieves data from all other processors
 
 
-                call scatter_points(live_points,live_point,mpi_information)
+                active_workers=mpi_information%nprocs-1 ! Set the number of active processors to the number of workers
 
-                ! if live points have been set to -1 then exit loop
-                if (any(live_point<0)) exit
+                do while(active_workers>0) 
 
-                time0 = time()
-                call calculate_point( loglikelihood, prior, live_point, settings,nlike) ! Compute physical coordinates, likelihoods and derived parameters
-                ndiscarded=ndiscarded+1
-                time1 = time()
-                live_point(settings%b0) = settings%logzero
-                if(live_point(settings%l0)>settings%logzero) total_time = total_time + time1-time0
-
-
-                call gather_points(live_points,live_point,mpi_information)
                     ! Recieve a point from any worker
+                    worker_id = catch_point(live_point,mpi_information)
 
-                if (is_root(mpi_information)) then
-                    do live_point_index=1, mpi_information%nprocs * settings%nTotal, settings%nTotal
-                        if (RTI%nlive(1)>=nprior) exit ! exit loop if enough points have been generated
+                    ! If its valid, add it to the array
+                    if(live_point(settings%l0)>settings%logzero) then
 
-                        live_point=live_points(live_point_index:live_point_index+settings%nTotal-1)
+                        call add_point(live_point,RTI%live,RTI%nlive,1) ! Add this point to the array
 
-                        ! If its valid, add it to the array
-                        if(live_point(settings%l0)>settings%logzero) then
+                        !-------------------------------------------------------------------------------!
+                        call write_generating_live_points(settings%feedback,RTI%nlive(1),nprior)
+                        !-------------------------------------------------------------------------------!
 
-                            call add_point(live_point,RTI%live,RTI%nlive,1) ! Add this point to the array
-
-                            !-------------------------------------------------------------------------------!
-                            call write_generating_live_points(settings%feedback,RTI%nlive(1),nprior)
-                            !-------------------------------------------------------------------------------!
-
-                            if(settings%write_live) then
-                                ! Write the live points to the live_points file
-                                write(write_phys_unit,fmt_dbl) live_point(settings%p0:settings%d1), live_point(settings%l0)
-                                flush(write_phys_unit) ! flush the unit to force write
-                            end if
+                        if(settings%write_live) then
+                            ! Write the live points to the live_points file
+                            write(write_phys_unit,fmt_dbl) live_point(settings%p0:settings%d1), live_point(settings%l0)
+                            flush(write_phys_unit) ! flush the unit to force write
                         end if
-                    end do
 
-                end if
+                    end if
 
 
-            end do
+                    if(RTI%nlive(1)<nprior) then
+                        call request_point(mpi_information,worker_id)  ! If we still need more points, send a signal to have another go
+                    else
+                        call no_more_points(mpi_information,worker_id) ! Otherwise, send a signal to stop
+                        active_workers=active_workers-1                ! decrease the active worker counter
+                    end if
+
+                end do
+
+
+
+
+            else
+
+                ! The workers simply generate and send points until they're told to stop by the administrator
+                do while(.true.)
+        
+                    live_point(settings%h0:settings%h1) = random_reals(settings%nDims)       ! Generate a random hypercube coordinate
+                    time0 = time()
+                    call calculate_point( loglikelihood, prior, live_point, settings,nlike) ! Compute physical coordinates, likelihoods and derived parameters
+                    ndiscarded=ndiscarded+1
+                    time1 = time()
+                    live_point(settings%b0) = settings%logzero
+                    if(live_point(settings%l0)>settings%logzero) total_time = total_time + time1-time0
+                    call throw_point(live_point,mpi_information)                                    ! Send it to the root node
+                    if(.not. more_points_needed(mpi_information)) exit                              ! If we've recieved a kill signal, then exit this loop
+
+                end do
+            end if
 #endif
         end if !(nprocs case)
 
@@ -606,7 +607,6 @@ module generate_module
 
                 ! The workers simply generate and send points until they're told to stop by the administrator
                 live_point = settings%seed_point
-                live_point = 0
                 do while(.true.)
                     do i_repeat = 1,settings%nprior_repeat
                         do i_dim=1,settings%nDims

--- a/src/polychord/generate.F90
+++ b/src/polychord/generate.F90
@@ -69,7 +69,7 @@ module generate_module
         use array_module,     only: add_point
         use abort_module
 #ifdef MPI
-        use mpi_module, only: mpi_bundle,is_root,linear_mode,throw_point,catch_point,more_points_needed,sum_integers,sum_doubles,request_point,no_more_points,request_this_point,point_needed
+        use mpi_module, only: mpi_bundle,is_root,linear_mode,throw_point,catch_point,more_points_needed,sum_integers,sum_doubles,request_point,no_more_points,request_live_point,live_point_needed
 #else
         use mpi_module, only: mpi_bundle,is_root,linear_mode
 #endif
@@ -198,7 +198,7 @@ module generate_module
                     ! use the time as an ordering identifier, cheat by using the birth contour
                     live_point(settings%b0) = ngenerated
                     ngenerated = ngenerated+1
-                    call request_this_point(live_point,mpi_information,worker_id)
+                    call request_live_point(live_point,mpi_information,worker_id)
                 end do
 
                 do while(active_workers>0) 
@@ -229,7 +229,7 @@ module generate_module
                         ! use the time as a unique identifier, cheat by using the birth contour
                         live_point(settings%b0) = ngenerated
                         ngenerated = ngenerated+1
-                        call request_this_point(live_point,mpi_information,worker_id)
+                        call request_live_point(live_point,mpi_information,worker_id)
                     else
                         call no_more_points(mpi_information,worker_id) ! Otherwise, send a signal to stop
                         active_workers=active_workers-1                ! decrease the active worker counter
@@ -248,7 +248,7 @@ module generate_module
 
                 ! The workers simply generate and send points until they're told to stop by the administrator
                 
-                do while(point_needed(live_point,mpi_information))
+                do while(live_point_needed(live_point,mpi_information))
                     time0 = time()
                     call calculate_point( loglikelihood, prior, live_point, settings,nlike) ! Compute physical coordinates, likelihoods and derived parameters
                     ndiscarded=ndiscarded+1

--- a/src/polychord/mpi_utils.F90
+++ b/src/polychord/mpi_utils.F90
@@ -371,17 +371,17 @@ module mpi_module
     !============= Generating live points =================
     !> 
     !!
-    !! This a process by which the worker node 'catches' thrown points
-    !! from the administrator
+    !! This a process by which the administrator 'scatters' live points
+    !! to all workers.
 
-    !> Administrator throws points to all workers
+    !> Administrator scatters live points to all workers.
     !!
     !! This a process by which a worker node 'throws' a point to the root
 
     subroutine scatter_points(live_points,live_point,mpi_information,nTotal)
         implicit none
 
-        real(dp),intent(in),dimension(:) :: live_points !> live point to throw
+        real(dp),intent(in),dimension(:) :: live_points !> live points to throw
         real(dp),intent(out),dimension(:) :: live_point !> live point to catch
         type(mpi_bundle), intent(in) :: mpi_information
         integer, intent(in) :: nTotal
@@ -401,11 +401,16 @@ module mpi_module
     end subroutine scatter_points
 
 
+    !> Administrator gathers live points from all workers.
+    !!
+    !! This a process by which the administrator node 'gathers'
+    !! all points to the root.
+
 
     subroutine gather_points(live_points,live_point,mpi_information,nTotal)
         implicit none
 
-        real(dp),intent(in),dimension(:) :: live_point !> live point to throw
+        real(dp),intent(in),dimension(:) :: live_point   !> live point to throw
         real(dp),intent(out),dimension(:) :: live_points !> live points to catch
         type(mpi_bundle), intent(in) :: mpi_information
         integer, intent(in) :: nTotal

--- a/src/polychord/mpi_utils.F90
+++ b/src/polychord/mpi_utils.F90
@@ -368,69 +368,6 @@ module mpi_module
 
 
 
-    !============== Scattering/gathering live points ====================
-    ! This a process by which the administrator 'scatters' live points
-    ! to all workers, and gathers them back again.
-    !
-    ! This is used in the initial generation of live points.
-    ! scatter_points:
-    !    root     ---->   all workers
-    !
-    ! gather_points:
-    ! all workers ---->   root
-
-    !> Administrator scatters live points to all workers.
-    !!
-    !! This a process by which a worker node 'throws' a point to the root
-
-    subroutine scatter_points(live_points,live_point,mpi_information)
-        implicit none
-
-        real(dp),intent(in),dimension(:) :: live_points !> live points to throw
-        real(dp),intent(out),dimension(:) :: live_point !> live point to catch
-        type(mpi_bundle), intent(in) :: mpi_information
-
-        call MPI_SCATTER(                &!
-            live_points,                 &!
-            size(live_point),            &!
-            MPI_DOUBLE_PRECISION,        &!
-            live_point,                  &!
-            size(live_point),            &!
-            MPI_DOUBLE_PRECISION,        &!
-            mpi_information%root,        &!
-            mpi_information%communicator,&!
-            mpierror                     &!
-            )
-
-    end subroutine scatter_points
-
-
-    !> Administrator gathers live points from all workers.
-    !!
-    !! This a process by which the administrator node 'gathers'
-    !! all points to the root.
-
-
-    subroutine gather_points(live_points,live_point,mpi_information)
-        implicit none
-
-        real(dp),intent(in),dimension(:) :: live_point   !> live point to throw
-        real(dp),intent(out),dimension(:) :: live_points !> live points to catch
-        type(mpi_bundle), intent(in) :: mpi_information
-
-        call MPI_GATHER(                 &!
-            live_point,                  &!
-            size(live_point),            &!
-            MPI_DOUBLE_PRECISION,        &!
-            live_points,                 &!
-            size(live_point),            &!
-            MPI_DOUBLE_PRECISION,        &!
-            mpi_information%root,        &!
-            mpi_information%communicator,&!
-            mpierror                     &!
-            )
-
-    end subroutine gather_points
 
 
 

--- a/src/polychord/mpi_utils.F90
+++ b/src/polychord/mpi_utils.F90
@@ -693,20 +693,15 @@ module mpi_module
 
     end function more_points_needed
 
-
-    !============== New messaging routines ===========================
-    ! Fix this later!
-    ! During initial live point generation, the administrator needs to signal to the workers
-    ! whether or not to keep generating live points, or whether to stop
-    !
-    ! administrator         ----> worker
-    ! request_point        more_points_needed -> true
-    ! no_more_points       more_points_needed -> false
+    !> Request specific live points
+    ! administrator                     ----> worker
+    ! request_this_point(live_point)   point_needed -> true
+    ! no_more_points (defined above)   point_needed -> false
     ! 
 
-    !> Request point
+    !> Request this point
     !!
-    !! This subroutine is used by the root node to request a new live point
+    !! This subroutine is used by the root node to request a specific live point
     subroutine request_this_point(live_point,mpi_information,worker_id)
         implicit none
         type(mpi_bundle), intent(in) :: mpi_information
@@ -726,9 +721,9 @@ module mpi_module
 
     end subroutine request_this_point
 
-    !> See if more points are needed
+    !> See if another point is needed
     !!
-    !! This subroutine is used by the root node to request a new live point
+    !! This subroutine is used by the root node to request a specific live point
     function point_needed(live_point,mpi_information)
         use abort_module
         implicit none

--- a/src/polychord/mpi_utils.F90
+++ b/src/polychord/mpi_utils.F90
@@ -383,20 +383,19 @@ module mpi_module
     !!
     !! This a process by which a worker node 'throws' a point to the root
 
-    subroutine scatter_points(live_points,live_point,mpi_information,nTotal)
+    subroutine scatter_points(live_points,live_point,mpi_information)
         implicit none
 
         real(dp),intent(in),dimension(:) :: live_points !> live points to throw
         real(dp),intent(out),dimension(:) :: live_point !> live point to catch
         type(mpi_bundle), intent(in) :: mpi_information
-        integer, intent(in) :: nTotal
 
         call MPI_SCATTER(                &!
             live_points,                 &!
-            nTotal,                      &!
+            size(live_point),            &!
             MPI_DOUBLE_PRECISION,        &!
             live_point,                  &!
-            nTotal,                      &!
+            size(live_point),            &!
             MPI_DOUBLE_PRECISION,        &!
             mpi_information%root,        &!
             mpi_information%communicator,&!
@@ -412,20 +411,19 @@ module mpi_module
     !! all points to the root.
 
 
-    subroutine gather_points(live_points,live_point,mpi_information,nTotal)
+    subroutine gather_points(live_points,live_point,mpi_information)
         implicit none
 
         real(dp),intent(in),dimension(:) :: live_point   !> live point to throw
         real(dp),intent(out),dimension(:) :: live_points !> live points to catch
         type(mpi_bundle), intent(in) :: mpi_information
-        integer, intent(in) :: nTotal
 
         call MPI_GATHER(                 &!
             live_point,                  &!
-            nTotal,                      &!
+            size(live_point),            &!
             MPI_DOUBLE_PRECISION,        &!
             live_points,                 &!
-            nTotal,                      &!
+            size(live_point),            &!
             MPI_DOUBLE_PRECISION,        &!
             mpi_information%root,        &!
             mpi_information%communicator,&!

--- a/src/polychord/mpi_utils.F90
+++ b/src/polychord/mpi_utils.F90
@@ -368,11 +368,16 @@ module mpi_module
 
 
 
-    !============= Generating live points =================
-    !> 
-    !!
-    !! This a process by which the administrator 'scatters' live points
-    !! to all workers.
+    !============== Scattering/gathering live points ====================
+    ! This a process by which the administrator 'scatters' live points
+    ! to all workers, and gathers them back again.
+    !
+    ! This is used in the initial generation of live points.
+    ! scatter_points:
+    !    root     ---->   all workers
+    !
+    ! gather_points:
+    ! all workers ---->   root
 
     !> Administrator scatters live points to all workers.
     !!

--- a/src/polychord/mpi_utils.F90
+++ b/src/polychord/mpi_utils.F90
@@ -368,6 +368,61 @@ module mpi_module
 
 
 
+    !============= Generating live points =================
+    !> 
+    !!
+    !! This a process by which the worker node 'catches' thrown points
+    !! from the administrator
+
+    !> Administrator throws points to all workers
+    !!
+    !! This a process by which a worker node 'throws' a point to the root
+
+    subroutine scatter_points(live_points,live_point,mpi_information,nTotal)
+        implicit none
+
+        real(dp),intent(in),dimension(:) :: live_points !> live point to throw
+        real(dp),intent(out),dimension(:) :: live_point !> live point to catch
+        type(mpi_bundle), intent(in) :: mpi_information
+        integer, intent(in) :: nTotal
+
+        call MPI_SCATTER(                &!
+            live_points,                 &!
+            nTotal,                      &!
+            MPI_DOUBLE_PRECISION,        &!
+            live_point,                  &!
+            nTotal,                      &!
+            MPI_DOUBLE_PRECISION,        &!
+            mpi_information%root,        &!
+            mpi_information%communicator,&!
+            mpierror                     &!
+            )
+
+    end subroutine scatter_points
+
+
+
+    subroutine gather_points(live_points,live_point,mpi_information,nTotal)
+        implicit none
+
+        real(dp),intent(in),dimension(:) :: live_point !> live point to throw
+        real(dp),intent(out),dimension(:) :: live_points !> live points to catch
+        type(mpi_bundle), intent(in) :: mpi_information
+        integer, intent(in) :: nTotal
+
+        call MPI_GATHER(                 &!
+            live_point,                  &!
+            nTotal,                      &!
+            MPI_DOUBLE_PRECISION,        &!
+            live_points,                 &!
+            nTotal,                      &!
+            MPI_DOUBLE_PRECISION,        &!
+            mpi_information%root,        &!
+            mpi_information%communicator,&!
+            mpierror                     &!
+            )
+
+    end subroutine gather_points
 
 
 


### PR DESCRIPTION
Currently, live point generation (and therefore the entire algorithm) is non-deterministic, even if the seed is fixed.

### Old approach:
Root process waits as `nprocs-1` other processes generate live points at random positions, calculate logL and pass to the root, and keep going until told to stop when the root has nprior samples.
The issue here is that the processes will run at different speeds, leading to the random number generations getting all mixed up.


### ~New approach:~
~Root process generates `nprocs` random live points, and scatters these to all processes (including itself). Each process calculates logL and the results are gathered. The root then adds the points >log0, and repeats the above until it has `nprior` (and sends arrays full of -1 to tell the other workers to stop).
This way, only the root is generating random numbers, so they will appear in the same order for a given seed.~

### ~Possible issues:~
~Since the root waits for all workers to complete their calculation, if one of them gets stuck, the whole algorithm will get stuck.~

### Second pass:
A simpler approach is to just offload all the random number generation to the root node, and pass this along when requesting points from the workers.  The key is that PolyChord waits for all active workers to finish generating prior samples before it moves on.

This avoids the issue from the first pass where all workers have to wait for a slow evaluation.