### PR TITLE
lmpi_cxx flag for Makefile_gnu

### DIFF
--- a/Makefile_gnu
+++ b/Makefile_gnu
@@ -32,7 +32,7 @@ endif
 ifneq (,$(findstring clang,$(shell '$(CXX)' -v 2>&1)))
 LDLIBS += -lc++
 else
-LDLIBS += -lstdc++
+LDLIBS += -lstdc++ -lmpi_cxx
 endif
 
 

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@
    :target: https://arxiv.org/abs/1506.00171
    :alt: Open-access paper
 
-PolyChord v 1.21.3
+PolyChord v 1.21.4
 
 Will Handley, Mike Hobson & Anthony Lasenby
 

--- a/pypolychord/__init__.py
+++ b/pypolychord/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "1.21.3"
+__version__ = "1.21.4"
 from pypolychord.settings import PolyChordSettings
 from pypolychord.polychord import run_polychord

--- a/src/polychord/feedback.f90
+++ b/src/polychord/feedback.f90
@@ -28,7 +28,7 @@ module feedback_module
             write(stdout_unit,'("")')
             write(stdout_unit,'("PolyChord: Next Generation Nested Sampling")')
             write(stdout_unit,'("copyright: Will Handley, Mike Hobson & Anthony Lasenby")')
-            write(stdout_unit,'("  version: 1.21.3")')
+            write(stdout_unit,'("  version: 1.21.4")')
             write(stdout_unit,'("  release: 9th Jan 2024")')
             write(stdout_unit,'("    email: wh260@mrao.cam.ac.uk")')
             write(stdout_unit,'("")')


### PR DESCRIPTION
As shown in #95 by @BorisDeletic, we need to add -lmpi_cxx to Makefile_gnu to compile.

Closes #95
