### PR TITLE
create the parameter names file earlier

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@
    :target: https://arxiv.org/abs/1506.00171
    :alt: Open-access paper
 
-PolyChord v 1.22.0
+PolyChord v 1.22.1
 
 Will Handley, Mike Hobson & Anthony Lasenby
 

--- a/pypolychord/__init__.py
+++ b/pypolychord/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "1.22.0"
+__version__ = "1.22.1"
 from pypolychord.settings import PolyChordSettings
 from pypolychord.polychord import run_polychord, run

--- a/pypolychord/polychord.py
+++ b/pypolychord/polychord.py
@@ -519,12 +519,6 @@ def run(loglikelihood, nDims, **kwargs):
 
     paramnames = kwargs.pop('paramnames', None)
 
-    if paramnames is not None:
-        PolyChordOutput.make_paramnames_file(
-            paramnames,
-            Path(kwargs['base_dir']) /
-                (kwargs['file_root'] + ".paramnames"))
-
     default_kwargs = {
         'nDerived': 0,
         'prior': default_prior,
@@ -572,6 +566,12 @@ def run(loglikelihood, nDims, **kwargs):
     if rank == 0:
         (Path(kwargs['base_dir']) / kwargs['cluster_dir']).mkdir(
             parents=True, exist_ok=True)
+        if paramnames is not None:
+            PolyChordOutput.make_paramnames_file(
+                paramnames,
+                Path(kwargs['base_dir']) /
+                    (kwargs['file_root'] + ".paramnames"))
+
 
     if 'cube_samples' in kwargs:
         _make_resume_file(loglikelihood, kwargs['prior'], **kwargs)

--- a/pypolychord/polychord.py
+++ b/pypolychord/polychord.py
@@ -519,6 +519,12 @@ def run(loglikelihood, nDims, **kwargs):
 
     paramnames = kwargs.pop('paramnames', None)
 
+    if paramnames is not None:
+        PolyChordOutput.make_paramnames_file(
+            paramnames,
+            Path(kwargs['base_dir']) /
+                (kwargs['file_root'] + ".paramnames"))
+
     default_kwargs = {
         'nDerived': 0,
         'prior': default_prior,
@@ -629,12 +635,6 @@ def run(loglikelihood, nDims, **kwargs):
 
     if 'cube_samples' in kwargs:
         kwargs['read_resume'] = read_resume
-
-    if paramnames is not None:
-        PolyChordOutput.make_paramnames_file(
-            paramnames,
-            Path(kwargs['base_dir']) /
-                (kwargs['file_root'] + ".paramnames"))
 
     try:
         import anesthetic

--- a/src/polychord/feedback.f90
+++ b/src/polychord/feedback.f90
@@ -28,7 +28,7 @@ module feedback_module
             write(stdout_unit,'("")')
             write(stdout_unit,'("PolyChord: Next Generation Nested Sampling")')
             write(stdout_unit,'("copyright: Will Handley, Mike Hobson & Anthony Lasenby")')
-            write(stdout_unit,'("  version: 1.22.0")')
+            write(stdout_unit,'("  version: 1.22.1")')
             write(stdout_unit,'("  release: 10th Jan 2024")')
             write(stdout_unit,'("    email: wh260@mrao.cam.ac.uk")')
             write(stdout_unit,'("")')


### PR DESCRIPTION
In the new `pypolychord.run()`, the `.paramnames` file isn't created until after nested sampling is complete. This makes it difficult to read in chains which are still running, or have crashed.

I've moved the call to `make_paramnames_file()` much earlier so this should no longer be a problem.