### PR TITLE
Refactor C/Fortran interfaces and enforce non-executable stack

### DIFF
--- a/Makefile_gnu
+++ b/Makefile_gnu
@@ -35,6 +35,7 @@ else
 LDLIBS += -lstdc++
 endif
 
+LDLIBS += -Wl,-z,noexecstack
 
 detected_OS := $(shell uname -s)
 ifeq ($(detected_OS),Darwin)

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@
    :target: https://arxiv.org/abs/1506.00171
    :alt: Open-access paper
 
-PolyChord v 1.22.1
+PolyChord v 1.22.2
 
 Will Handley, Mike Hobson & Anthony Lasenby
 

--- a/pypolychord/__init__.py
+++ b/pypolychord/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "1.22.1"
+__version__ = "1.22.2"
 from pypolychord.settings import PolyChordSettings
 from pypolychord.polychord import run_polychord, run

--- a/src/polychord/feedback.f90
+++ b/src/polychord/feedback.f90
@@ -28,7 +28,7 @@ module feedback_module
             write(stdout_unit,'("")')
             write(stdout_unit,'("PolyChord: Next Generation Nested Sampling")')
             write(stdout_unit,'("copyright: Will Handley, Mike Hobson & Anthony Lasenby")')
-            write(stdout_unit,'("  version: 1.22.1")')
+            write(stdout_unit,'("  version: 1.22.2")')
             write(stdout_unit,'("  release: 10th Jan 2024")')
             write(stdout_unit,'("    email: wh260@mrao.cam.ac.uk")')
             write(stdout_unit,'("")')


### PR DESCRIPTION
• Added the linker flag "-Wl,-z,noexecstack" in Makefile_gnu to disable executable stacks for improved security.
• In src/polychord/interfaces.F90:
move all functions defined internally in contains functions to module-level definitions with module-level variables.

This fixes the bug found in #124 which has arisen for glibc 2.41 which does not allow executable stack calls