### PR TITLE
fix: ensure MPI & Intel libs found during pip install (keep env vars)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,8 +76,16 @@ class CustomBuildPy(_build_py, object):
     def run(self):
         env = {}
         env["PATH"] = os.environ["PATH"]
+        # Ensure that the library paths are set correctly in build environment
+        for var in ("LD_LIBRARY_PATH", "LIBRARY_PATH"):
+            if var in os.environ:
+                env[var] = os.environ[var]
+        # Check if we are building with MPI support
         if self.distribution.no_mpi is None:
             env["MPI"] = "1"
+            # Copy over I_MPI_ROOT for intel MPI builds if it exists
+            if "I_MPI_ROOT" in os.environ:
+                env["I_MPI_ROOT"] = os.environ["I_MPI_ROOT"]
             # These need to be set so that build_ext uses the right compilers
             cc_compiler = subprocess.check_output(["make", "print_CC"]).decode('utf-8').strip()
             os.environ["CC"] = cc_compiler


### PR DESCRIPTION
Just getting starting with PolyChord but I had an issue with installation via python setup.py install on a cluster (Imperial College).

The build environment didn't carry over the necessary library and mpi paths to allow compilation.

Without I_MPI_ROOT, the build would fail on the include mpif.h in utils.F90 as it can't find mpif.h

Without library paths, build would fail at the linking stage as it couldn't find libimf.so

Following additions to setup.py allowed compilation.


**Software version info:**
The modules loaded where:
```
Currently Loaded Modulefiles:
 1) tools/prod            3) zlib/1.2.13-GCCcore-13.2.0 <aL>     5) intel-compilers/2023.2.1             7) UCX/1.15.0-GCCcore-13.2.0 <aL>           
 2) GCCcore/13.2.0 <aL>   4) binutils/2.40-GCCcore-13.2.0 <aL>   6) numactl/2.0.16-GCCcore-13.2.0 <aL>   8) impi/2021.10.0-intel-compilers-2023.2.1  

Key:
<module-tag>  <aL>=auto-loaded  
```

which mpiifort returns:
```
/sw-eb/software/impi/2021.10.0-intel-compilers-2023.2.1/mpi/2021.10.0/bin/mpiifort
```