### PR TITLE
Fix CI: Update Python version support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v3
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,10 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
-        include:
-          - os: ubuntu-20.04
-            python-version: '3.6'
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3
@@ -46,7 +43,6 @@ jobs:
       run: mpirun --oversubscribe -np 3 python run_pypolychord.py
 
     - name: Test pypolychord (anesthetic)
-      if: ${{ ! contains( '3.6, 3.7', matrix.python-version ) }}
       run: |
         pip install -r requirements.txt
         python run_pypolychord.py


### PR DESCRIPTION
## Summary
- Remove Python 3.6 and 3.7 which are no longer available on Ubuntu 24.04 (ubuntu-latest)
- Add Python 3.12 support which is now stable and widely supported
- Remove conditional check for anesthetic tests since all supported versions now support it

## Changes
- Updated CI matrix to test Python 3.8, 3.9, 3.10, 3.11, and 3.12
- Python 3.6 reached EOL in December 2021
- Python 3.7 reached EOL in June 2023  
- Python 3.12 is stable and supported by NumPy and the scientific ecosystem

## Test plan
- [x] CI pipeline runs successfully with updated Python versions
- [x] All existing functionality preserved
- [x] No breaking changes to the codebase

🤖 Generated with [Claude Code](https://claude.ai/code)