### PR TITLE
Fix CC examples debug mode vector access issue

### DIFF
--- a/src/polychord/c_interface.cpp
+++ b/src/polychord/c_interface.cpp
@@ -102,11 +102,11 @@ void run_polychord(
             base_dir,
             file_root,
             s.grade_frac.size(),
-            &s.grade_frac[0],
-            &s.grade_dims[0],
+            s.grade_frac.data(),
+            s.grade_dims.data(),
             s.loglikes.size(),
-            &s.loglikes[0],
-            &s.nlives[0],
+            s.loglikes.data(),
+            s.nlives.data(),
             s.seed,
 				fortran_comm
                 );


### PR DESCRIPTION
## Summary
Fixes issue #127 where CC examples fail in debug mode with vector assertion errors.

## Problem
In debug mode, STL vectors include bounds checking. The original code used `&vec[0]` to get pointers to vector data, which triggers assertion failures when vectors are empty because accessing `vec[0]` on an empty vector is undefined behavior.

## Solution
Replaced all instances of `&vec[0]` with `vec.data()` in `c_interface.cpp`:
- `&s.grade_frac[0]` → `s.grade_frac.data()`
- `&s.grade_dims[0]` → `s.grade_dims.data()` 
- `&s.loglikes[0]` → `s.loglikes.data()`
- `&s.nlives[0]` → `s.nlives.data()`

The `vec.data()` method is safe for empty vectors and provides the same functionality.

## Testing
- ✅ Tested in debug mode (`DEBUG=1`) - no more assertion failures
- ✅ Tested in normal mode - functionality preserved
- ✅ Both Fortran and C++ interfaces work correctly

## Compatibility
This fix is compatible with C++11 and later (which PolyChord already requires) and doesn't change the public API.

Closes #127

🤖 Generated with [Claude Code](https://claude.ai/code)