### PR TITLE
Release: 1.23.0 (and change CI to run on Mondays only)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v3
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [ master ]
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 0 * * 1"
 
   workflow_dispatch:
 

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@
    :target: https://arxiv.org/abs/1506.00171
    :alt: Open-access paper
 
-PolyChord v 1.22.3
+PolyChord v 1.23.0
 
 Will Handley, Mike Hobson & Anthony Lasenby
 

--- a/pypolychord/__init__.py
+++ b/pypolychord/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "1.22.3"
+__version__ = "1.23.0"
 from pypolychord.settings import PolyChordSettings
 from pypolychord.polychord import run_polychord, run

--- a/src/polychord/feedback.f90
+++ b/src/polychord/feedback.f90
@@ -28,8 +28,8 @@ module feedback_module
             write(stdout_unit,'("")')
             write(stdout_unit,'("PolyChord: Next Generation Nested Sampling")')
             write(stdout_unit,'("copyright: Will Handley, Mike Hobson & Anthony Lasenby")')
-            write(stdout_unit,'("  version: 1.22.3")')
-            write(stdout_unit,'("  release: 22nd Nov 2025")')
+            write(stdout_unit,'("  version: 1.23.0")')
+            write(stdout_unit,'("  release: 25th Nov 2025")')
             write(stdout_unit,'("    email: wh260@mrao.cam.ac.uk")')
             write(stdout_unit,'("")')
         end if


### PR DESCRIPTION
Minor version bump due to the spelling change of identifiability in #122 

Edit: running the CI daily is clogging up the organisation, and is probably excessive. Changed to run on Monday at midnight.