### PR TITLE
`cluster_dir` actually can't be changed!

### DIFF
--- a/pypolychord/polychord.py
+++ b/pypolychord/polychord.py
@@ -419,10 +419,6 @@ def run(loglikelihood, nDims, **kwargs):
         (Default: 'test')
         Root name of the files produced.
 
-    cluster_dir : string
-        (Default: 'clusters')
-        Where to store clustering files. (base_dir/cluster_dir)
-
     grade_frac : List[float]
         (Default: [1])
         The amount of time to spend in each speed.
@@ -548,7 +544,6 @@ def run(loglikelihood, nDims, **kwargs):
         'synchronous': True,
         'base_dir': 'chains',
         'file_root': 'test',
-        'cluster_dir': 'clusters',
         'grade_dims': [nDims],
         'nlives': {},
         'seed': -1,
@@ -565,7 +560,7 @@ def run(loglikelihood, nDims, **kwargs):
     kwargs = default_kwargs
 
     if rank == 0:
-        (Path(kwargs['base_dir']) / kwargs['cluster_dir']).mkdir(
+        (Path(kwargs['base_dir']) / 'clusters').mkdir(
             parents=True, exist_ok=True)
         if paramnames is not None:
             PolyChordOutput.make_paramnames_file(


### PR DESCRIPTION
When adding the new `run()` interface, I didn't realise that `cluster_dir` is baked in as `base_dir/'clusters'`, and is only really in `PolyChordSettings` so that the directory can be made at startup in python. This PR removes this erroneous `kwarg`.